### PR TITLE
rename enterprise engineer to on-site engineer

### DIFF
--- a/2015 q3 on-site engineer.md
+++ b/2015 q3 on-site engineer.md
@@ -1,0 +1,47 @@
+## On-Site Engineer
+
+When companies need an on-premise npm registry, [npm
+On-Site](http://npm.im/onsite) is the solution we offer them.
+npm On-Site runs the exact same codebase as the public registry
+running at <https://registry.npmjs.org>.
+
+Since we had to build most of the parts in order to facilitate running
+the public registry, we started selling npm On-Site back in
+mid-2014.  Despite not having been a top company priority, it's been
+picked up by a few of the biggest companies in the world, and reflects
+a very significant portion of npm, Inc.'s revenue.
+
+Our goal is for this product to eventually be absolutely trivial for
+our customers to buy, install, administer, and manage, as part of
+npm's mission of reducing friction at all stages of JavaScript
+software developent.
+
+As npm's On-Site Engineer, you'll work on the last mile of making
+npm On-Site the product that our customers need.  You'll also be
+working with customers directly to figure out what those needs are,
+and helping them to be successful.
+
+You'll be working closely with the Registry Team (since the codebases
+overlap almost entirely), and also assisting with the sales and
+onboarding process in order to get a feel for what matters most to our
+users.
+
+npm is an open-source focused company. Despite npm On-Site being one
+of our flagship paid products, we hope to take steps towards open-sourcing
+many of its components. This will be an important aspect of your job.
+
+Your work will have a significant impact in the company's bottom line,
+while improving the lives of our users in an immediate and tangible
+way.  There is a ton of low-hanging fruit, and plenty of interesting
+challenges beyond.
+
+We're looking for someone who combines technical ability with empathy
+and a genuine interest in helping customers.  We don't want you
+solving the same problems over and over again; we want you improving
+the product so that common problems go away.  A background in
+consulting or technical support is useful, but not required.
+
+We prefer candidates who are local to our offices in downtown Oakland,
+California, but are open to remote work for the right candidate.  We
+cannot currently sponsor new work visas other than TN-1s, and we can
+transfer existing H-1Bs.

--- a/2015 q3 on-site engineer.md
+++ b/2015 q3 on-site engineer.md
@@ -7,8 +7,8 @@ running at <https://registry.npmjs.org>.
 
 Since we had to build most of the parts in order to facilitate running
 the public registry, we started selling npm On-Site back in
-mid-2014.  Despite not having been a top company priority, it's been
-picked up by a few of the biggest companies in the world, and reflects
+mid-2014.  We are increasing our focus on npm On-Site, a product that's
+been picked up by a few of the biggest companies in the world, and reflects
 a very significant portion of npm, Inc.'s revenue.
 
 Our goal is for this product to eventually be absolutely trivial for
@@ -26,7 +26,7 @@ overlap almost entirely), and also assisting with the sales and
 onboarding process in order to get a feel for what matters most to our
 users.
 
-npm is an open-source focused company. Despite npm On-Site being one
+npm is an open-source focused company. Because npm On-Site is one
 of our flagship paid products, we hope to take steps towards open-sourcing
 many of its components. This will be an important aspect of your job.
 


### PR DESCRIPTION
* rename enterprise engineering job to `on-site engineer`.
* emphasis the fact that this role affords opportunities for working on open-source-software.