### PR TITLE
product-designer job req

### DIFF
--- a/2018/q1/product-designer.md
+++ b/2018/q1/product-designer.md
@@ -20,8 +20,7 @@ See our unabridged code of conduct [here](https://www.npmjs.com/policies/conduct
 You'll work closely with our head of product (who is also our CEO),
 and with our engineering team as well as other major
 stakeholders like marketing, sales, and support to improve current products
-and envision new ones to add value for our users. Your output will
-include workflows, information architecture, written product specs and
+and envision new ones to add value for our users. You'll help define and drive forward npm's product strategy as well as produce workflows, information architecture, written product specs and
 wireframes as appropriate.
 
 This position will be based in our offices in Oakland, CA, and we are

--- a/2018/q1/product-designer.md
+++ b/2018/q1/product-designer.md
@@ -1,42 +1,45 @@
 # Senior Product Designer
 
-npm is the package manager for all JavaScript, serving modules to over
+*about npm*
+npm is the package manager for all JavaScript, serving code modules to over
 11 million developers around the world. As a low-friction way to share
 code, it has facilitated some of the largest open source movements in
 web development. Since its invention in 2009, over 628,000 packages
 have been published. In 2018, nearly everybody who builds a website
 uses npm to help them do it.
 
-Our huge popularity presents us with a challenge and an opportunity:
-with billions of downloads every week, we know more about what's going
-on in the world of JavaScript than anybody else. How do we boil down
-this huge amount of data into information that helps our users write
-better software? We have insights into the quality, security,
-performance, and popularity of every package: how do we surface this
-to developers looking for packages? We know what the software
-development team at a company is building, how do we help management
-get a bigger picture?
+We believe that high-performing teams include people from different backgrounds and experiences who can challenge each other's assumptions with fresh perspectives. To that end, we actively seek a diverse pool of applicants, including those from historically marginalized groups — women, people with disabilities, people of color, formerly incarcerated people, people who are lesbian, gay, bisexual, transgender, and/or gender nonconforming, first and second generation immigrants, and people from low-income families.
 
-To solve these problems and give our users the best possible
-experience, npm is hiring a Senior Product Designer. Your job will be
-to take a holistic view of the entire npm experience, from the website
-to the command line client, and create cohesive and enjoyable
-experiences that let developers get real work done while giving
-managers insight into how software is being written. npm's ambition is
-to reduce friction for everyone in software development, and that will
-be your guiding purpose.
+*our code of conduct*
+npm exists to facilitate sharing code, by making it easy for JavaScript module developers to publish and distribute packages.
+npm is a piece of technology, but more importantly, it is a community.
+We believe that our mission is best served in an environment that is friendly, safe, and accepting; free from intimidation or harassment. We do not tolerate abusive behavior.
+See our unabridged code of conduct [here](https://www.npmjs.com/policies/conduct).
 
-You'll be tasked with getting inside our users' heads, applying
-empathy tactically to the puzzle of delivering a product vision within
-the constraints of what's possible in reality. While you might not be
-a software developer yourself, you are familiar with their experience
-and the challenges they face.
-
-You'll report directly to our head of product (who is also our CEO),
-and work closely with our engineering team as well as other major
-stakeholders like marketing, sales, and support. Your output will
+*about this role:*
+You'll work closely with our head of product (who is also our CEO),
+and with our engineering team as well as other major
+stakeholders like marketing, sales, and support to improve current products
+and envision new ones to add value for our users. Your output will
 include workflows, information architecture, written product specs and
 wireframes as appropriate.
 
 This position will be based in our offices in Oakland, CA, and we are
 not looking for remote candidates for this position.
+
+*you will love this role if you:*
+- value collaboration and diverse perspectives
+- enjoy brainstorming to define new products and improve existing ones
+- enjoy web development work
+- enjoy working with a variety of personal and professional styles
+- value transparency
+- value continuous growth
+
+*it may be helpful if you have experience with:*
+- product development
+- product management
+- user experience
+- information architecture
+- web development
+- working with distributed teams
+- leadership, consulting, or teaching


### PR DESCRIPTION
* added an abridged code of conduct and a link to our full version
* added a diversity statement (I adapted one I've had good responses to in the past; couldn't find an existing one for npm)
* reformatted some of our implicit requirements/wishlist into bulleted lists (but intentionally not "required skills/experience"
* edited out a lot of text that focused on npm value and context - they should be able to go to our website and learn about us if they are really interested, and we can use the interview process to sell them on the company
* removed the reporting-to piece as unnecessary at this stage (gives us more flexibility in case we want to tweak structure)